### PR TITLE
Only show the public docstrings in the manual

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CompatEntryUtilities"
 uuid = "8be7a408-1a4a-465c-8be3-3898d13eb8a5"
 authors = ["Dilum Aluthge", "contributors"]
-version = "2.0.0"
+version = "2.0.1"
 
 [deps]
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -11,4 +11,6 @@ Documentation for [CompatEntryUtilities](https://github.com/JuliaRegistries/Comp
 
 ```@autodocs
 Modules = [CompatEntryUtilities]
+Public = true
+Private = false
 ```


### PR DESCRIPTION
Private docstrings are not part of the public API and thus should not be listed in the manual.